### PR TITLE
More improvements

### DIFF
--- a/lib/SVN/Access.pm
+++ b/lib/SVN/Access.pm
@@ -108,8 +108,11 @@ sub verify_acl {
     # Check for references to undefined groups (Thanks Jesse!)
     my (%groups, @errors);
     if ($self->groups) {
+        # gather groups first, in case there are forward refs
         foreach my $group ($self->groups) {
             $groups{$group->name}++;
+        }
+        foreach my $group ($self->groups) {
             foreach my $k ($group->members) {
                 if ( $k =~ /^@(.*)/ ) {
                     unless ( $groups{$1} ) {

--- a/lib/SVN/Access.pm
+++ b/lib/SVN/Access.pm
@@ -110,6 +110,15 @@ sub verify_acl {
     if ($self->groups) {
         foreach my $group ($self->groups) {
             $groups{$group->name}++;
+            foreach my $k ($group->members) {
+                if ( $k =~ /^@(.*)/ ) {
+                    unless ( $groups{$1} ) {
+                        push(@errors, "[error] An authz rule (" . $group->name. ") refers to group '$1', which is undefined");
+                    }
+                } elsif ( $k =~ /^&(.*)/ ) {
+                        push(@errors, "[error] An authz rule (" . $group->name . ") refers to alias '$1', which is undefined");
+                }
+            }
         }
     }
 
@@ -120,6 +129,8 @@ sub verify_acl {
                     unless ( $groups{$1} ) {
                         push(@errors, "[error] An authz rule (" . $resource->name . ") refers to group '\@$1', which is undefined");
                     }
+                } elsif ( $k =~ /^&(.*)/ ) {
+                    push(@errors, "[error] An authz rule (" . $resource->name . ") refers to alias '\&$1', which is undefined");
                 }
             }
         }

--- a/lib/SVN/Access.pm
+++ b/lib/SVN/Access.pm
@@ -116,7 +116,9 @@ sub verify_acl {
                         push(@errors, "[error] An authz rule (" . $group->name. ") refers to group '$1', which is undefined");
                     }
                 } elsif ( $k =~ /^&(.*)/ ) {
+                    unless ( $self->aliases->{$1} ) {
                         push(@errors, "[error] An authz rule (" . $group->name . ") refers to alias '$1', which is undefined");
+                    }
                 }
             }
         }
@@ -130,7 +132,9 @@ sub verify_acl {
                         push(@errors, "[error] An authz rule (" . $resource->name . ") refers to group '\@$1', which is undefined");
                     }
                 } elsif ( $k =~ /^&(.*)/ ) {
-                    push(@errors, "[error] An authz rule (" . $resource->name . ") refers to alias '\&$1', which is undefined");
+                    unless ( $self->aliases->{$1} ) {
+                        push(@errors, "[error] An authz rule (" . $resource->name . ") refers to alias '\&$1', which is undefined");
+                    }
                 }
             }
         }

--- a/lib/SVN/Access.pm
+++ b/lib/SVN/Access.pm
@@ -83,6 +83,9 @@ sub parse_acl {
                 $self->add_alias($k, $v);
             } else {
                 # this is a generic resource
+                unless ($v =~ /^[rw\s]*$/) {
+                    warn "Invalid character in authz rule $v\n";
+                }
                 if (my $resource = $self->resource($current_resource)) {
                     $resource->authorize($k => $v);
                 } else {

--- a/lib/SVN/Access.pm
+++ b/lib/SVN/Access.pm
@@ -36,6 +36,7 @@ sub parse_acl {
     while (my $line = <ACL>) {
         # ignore comments (properly defined)
         next if $line =~ /^#/;
+        $line =~ s/\s*#.*$// unless $self->{pedantic};
 
         # get rid of trailing whitespace.
         $line =~ s/[\s\r\n]+$//;
@@ -68,6 +69,12 @@ sub parse_acl {
             # both groups and resources need this parsed.
             my ($k, $v) = $statement =~ /^(.+?)\s*=\s*(.*?)$/;
 
+            # if the previous split didn't work, there's a syntax error
+            if (not $k)
+            {
+                warn "Unrecognized line $statement\n";
+                next;
+            }
             if ($current_resource eq "groups") {
                 # this is a group
                 $self->add_group($k, split(/\s*,\s*/, $v));
@@ -311,7 +318,7 @@ sub add_group {
     my ($self, $group_name, @initial_members) = @_;
 
     # get rid of the @ symbol.
-    $group_name =~ s/\@//g;
+    $group_name =~ s/\@//g unless $self->{pedantic};
 
     if ($self->group($group_name)) {
         die "Can't add new group $group_name: group already exists!\n";
@@ -353,6 +360,25 @@ sub group {
         return $group if defined($group) && $group->name eq $group_name;
     }
     return undef;
+}
+
+sub resolve {
+    my $self = shift;
+    my @res;
+    foreach my $e (@_) {
+        if ($e =~ /^\@(.+)/) {
+            push @res, map $self->resolve($_), $self->group($1)->members()
+                if $self->group($1);
+        }
+        elsif ($e =~ /^\&(.+)/) {
+            push @res, map $self->resolve($_), $self->alias($1)
+                if  $self->alias($1);
+        }
+        else {
+            push @res, $e;
+        }
+    }
+    return @res;
 }
 
 1;
@@ -551,6 +577,14 @@ Example:
   foreach my $alias (keys %{$acl->aliases}) {
     print "$alias: " . $acl->aliases->{$alias} . "\n";
   }
+
+=item B<resolve>
+
+Returns a fully resolved list of users part of the given groups and/or
+aliases.  Groups must be specified with a leading "@" and aliases with
+a leading "&", all else will be returned verbatim.  This recurses
+through all definitions to get actual user names (so groups within
+groups will be handled properly).
 
 =back
 

--- a/t/SVN-Access.t
+++ b/t/SVN-Access.t
@@ -155,6 +155,8 @@ $acl->add_resource(
         mike => 'rw',
     }
 );
+# ... and make sure it was understood
+is($acl->resource('/awesomeness')->authorized->{mike}, 'rw', 'was hash param understood?');
 
 # Jesse Thompson's verify_acl tests
 $acl->add_resource('/new', '@doesntexist', 'rw');
@@ -259,6 +261,7 @@ ugh = foo
 
 [/]
 broken_line = w
+foo = r@foobar = rw
 
 CHUMBA
 #/];# (keep emacs perl-mode happy)
@@ -270,9 +273,10 @@ $SIG{__WARN__} = sub { push @errs, @_; };
 
 $acl = eval { SVN::Access->new(acl_file => 'syntax-err.conf'); };
 ok(defined($acl), "Make sure we can parse file with syntax errors");
-is($#errs, 1, "Make sure we got the right number of errors");
+is($#errs, 2, "Make sure we got the right number of errors");
 ok($errs[0] =~ /^Unrecognized line two\s*/, "Make sure we detected the broken line syntax error");
 ok($errs[1] =~ /^Unrecognized line \[\]/, "Make sure we catch the bogus section divider");
+ok($errs[2] =~ /^Invalid character in authz rule/, "Make sure we catch the syntax error in rw spec");
 
 unlink('syntax-err.conf');
 

--- a/t/SVN-Access.t
+++ b/t/SVN-Access.t
@@ -307,12 +307,17 @@ unlink('expn.conf');
 # tests undefined groups and aliases
 open(STEST, '>', 'undef.conf');
 print STEST <<'CHUMBA';
+[aliases]
+right = correct
+
 [groups]
-broken = one, two, three, &none, @nada
+broken = one, two, three, &none, @nada, &right
 
 [/]
 @zip = rw
 &zilch = rw
+@broken = rw
+&right = rw
 
 CHUMBA
 #/];# (keep emacs perl-mode happy)

--- a/t/SVN-Access.t
+++ b/t/SVN-Access.t
@@ -195,6 +195,7 @@ missing=not
   
 # the line above contains some whitespace
 foo=bar # not allowed, baz
+@tempt = incorrect
 # see libsvn_subr/config_file.c:svn_config__parse_file()
 [/]
 @folks = rw
@@ -203,6 +204,7 @@ CHUMBA
 #/];# (keep emacs perl-mode happy)
 close(LTEST);
 
+# load in default mode
 $acl = SVN::Access->new(acl_file => 'line_cont.conf');
 ok(defined($acl), "Make sure we can parse file with line continuations");
 my @m = $acl->group('folks')->members;
@@ -211,9 +213,25 @@ is($m[2], "frank", "Make sure frank is at the end of the list");
 
 # check the trailing comment
 @m = $acl->group('foo')->members;
+is($#m, 0, "Make sure group has 1 members due to trailing comment");
+is($m[0], "bar", "make sure trailing comment was stripped");
+
+# check the incorrect group
+@m = $acl->group('tempt')->members;
+is($#m, 0, "Make sure group with @ is renamed and has one member");
+is($m[0], "incorrect", "Make sure that group has correct member");
+
+# no reload in pedantic mode and make sure the @ got left on the group
+$acl = SVN::Access->new(acl_file => 'line_cont.conf', pedantic => 1);
+@m = $acl->group('@tempt')->members;
+is($#m, 0, "Make sure group with @ has the name preserved (as svn allows)");
+is($m[0], "incorrect", "Make sure group with @ has proper membership");
+
+# check for trailing comment handling
+@m = $acl->group('foo')->members;
 is($#m, 1, "Make sure group has 2 members");
-is($m[0], "bar # not allowed", "make sure comment is appended as svn does");
-is($m[1], "baz", "make sure next entry is right");
+is($m[0], "bar # not allowed", "Make sure comment is appended as svn does");
+is($m[1], "baz", "Make sure next entry is right");
 
 # check for handling lines with whitespace... they should not get treated as
 # line continuations
@@ -221,4 +239,61 @@ is(ref $acl->group('missing'), "SVN::Access::Group",
    "Group before bogus line continuation should be present");
 
 unlink('line_cont.conf');
+
+# tests for syntax errors
+open(STEST, '>', 'syntax-err.conf');
+print STEST <<'CHUMBA';
+[groups]
+broken_line = one,
+two
+
+[]
+ugh = foo
+
+[/]
+broken_line = w
+
+CHUMBA
+#/];# (keep emacs perl-mode happy)
+close(STEST);
+
+# capture errors
+my @errs;
+$SIG{__WARN__} = sub { push @errs, @_; };
+
+$acl = eval { SVN::Access->new(acl_file => 'syntax-err.conf'); };
+ok(defined($acl), "Make sure we can parse file with syntax errors");
+is($#errs, 1, "Make sure we got the right number of errors");
+ok($errs[0] =~ /^Unrecognized line two\s*/, "Make sure we detected the broken line syntax error");
+ok($errs[1] =~ /^Unrecognized line \[\]/, "Make sure we catch the bogus section divider");
+
+unlink('syntax-err.conf');
+
+# tests for complex expansions
+open(STEST, '>', 'expn.conf');
+print STEST <<'CHUMBA';
+[groups]
+alicorn = &twilight
+earth = applejack
+unicorn = rarity
+pony = @alicorn, @earth, @unicorn
+
+[aliases]
+twilight = twilight_sparkle
+
+[/]
+pony = rw
+
+CHUMBA
+#/];# (keep emacs perl-mode happy)
+close(STEST);
+
+$acl = eval { SVN::Access->new(acl_file => 'expn.conf'); };
+ok(defined($acl), "Make sure we can parse complex file");
+@g = $acl->group("pony")->members();
+is($g[0], '@alicorn', "Make sure group returns groups unexpanded");
+@g = $acl->resolve('@pony');
+is($g[0], 'twilight_sparkle', 'Make sure resolve expands groups and aliases');
+
+unlink('expn.conf');
 

--- a/t/SVN-Access.t
+++ b/t/SVN-Access.t
@@ -230,8 +230,8 @@ is($m[0], "incorrect", "Make sure group with @ has proper membership");
 # check for trailing comment handling
 @m = $acl->group('foo')->members;
 is($#m, 1, "Make sure group has 2 members");
-is($m[0], "bar # not allowed", "Make sure comment is appended as svn does");
-is($m[1], "baz", "Make sure next entry is right");
+is($m[0], "bar # not allowed", "make sure comment is appended as svn does");
+is($m[1], "baz", "make sure next entry is right");
 
 # check for handling lines with whitespace... they should not get treated as
 # line continuations

--- a/t/SVN-Access.t
+++ b/t/SVN-Access.t
@@ -309,9 +309,13 @@ open(STEST, '>', 'undef.conf');
 print STEST <<'CHUMBA';
 [aliases]
 right = correct
+backwards = &forwards
+forwards = backwards
 
 [groups]
 broken = one, two, three, &none, @nada, &right
+outoforder = @working
+working = yes
 
 [/]
 @zip = rw


### PR DESCRIPTION
I discovered a couple of problems with the code.  First, loops in group definitions could cause infinite recursion.  Secondly, in a resource rule the only things permitted after an = is r, w, or white space, anything else causes svn authz to choke.

In the course of implementing the latter, I unearthed another bug:  it seems add_resource() doesn't fully understand the "name => ..." syntax.  I added a test to expose the bug, but the fix seemed complex so I wanted you to look at it first.